### PR TITLE
remove `date` function from the version API

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -10,8 +10,4 @@
   (targets version.ml)
   (action
     (with-stdout-to %{targets}
-      (progn
-        (echo "let version = String.trim \"" %{version:calendar} "\"\n")
-        (echo "let date = String.trim \"")
-        (system date)
-        (echo "\"\n")))))
+      (echo "let version = String.trim \"" %{version:calendar} "\"\n"))))

--- a/src/version.mli
+++ b/src/version.mli
@@ -26,5 +26,3 @@
 val version: string
   (** Name of this version. *)
 
-val date: string
-  (** Date of compilation. *)


### PR DESCRIPTION
breaks compatibility for reproducible builds.
close #27