### PR TITLE
remove date property from version.mli

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -117,7 +117,6 @@ $(LIBDIR)/$(NAMELIB).cmxs: $(LIBDIR)/$(NAMELIB).cmxa
 
 src/version.ml: Makefile
 	echo "let version = \"$(VERSION)\"" > $@
-	echo "let date = \"`date`\"" >> $@
 
 META: Makefile
 	echo "name = \"$(NAME)\"" > $@

--- a/src/version.mli
+++ b/src/version.mli
@@ -25,6 +25,3 @@
 
 val version: string
   (** Name of this version. *)
-
-val date: string
-  (** Date of compilation. *)


### PR DESCRIPTION
Storing build times into a binary was never a good idea, it usually carries
zero information about the used sources and the way the binary was produced.
Specifically, it breaks the concept of reproducible builds:
https://reproducible-builds.org/

Fixes #27

Signed-off-by: Olaf Hering <olaf@aepfle.de>