### PR TITLE
Add missing dependencies on Str and Unix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -86,7 +86,7 @@ GENERATED= src/version.ml
 
 CAMLIBS	= $(addprefix -I , $(DIRS))
 
-CAMLFLAGS= $(CAMLIBS)
+CAMLFLAGS= $(CAMLIBS) -I +unix -I +str
 BYTEFLAGS= $(CAMLFLAGS)
 LINK_OPTFLAGS = $(CAMLFLAGS) -noassert
 OPTFLAGS = $(LINK_OPTFLAGS) -for-pack CalendarLib


### PR DESCRIPTION
Provides compatibility to silence the alert proposed in ocaml/ocaml#11198. The change is compatible with previous OCaml releases, but it's obviously not worth merging this unless/until the OCaml PR is accepted.